### PR TITLE
Add donor profile page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import DonateurContributions from './pages/donateur/DonateurContributions';
 import ProjectDetail from './pages/donateur/ProjectDetail';
 import NotificationsPage from './pages/notifications/NotificationsPage';
 import ProjectDocuments from './pages/prestataire/ProjectDocuments';
+import ProfilePage from './pages/ProfilePage';
 
 import './App.css';
 
@@ -136,6 +137,14 @@ function App() {
             <ProtectedRoute>
               <Layout>
                 <NotificationsPage />
+              </Layout>
+            </ProtectedRoute>
+          } />
+
+          <Route path="/profile" element={
+            <ProtectedRoute>
+              <Layout>
+                <ProfilePage />
               </Layout>
             </ProtectedRoute>
           } />

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -22,7 +22,7 @@ const Header: React.FC<HeaderProps> = ({ onMenuToggle }) => {
         
         <div className="hidden lg:block">
           <h2 className="text-xl font-semibold text-gray-800">
-            Bienvenue, {user?.name}
+            Bienvenue, {user ? `${user.prenom} ${user.nom}` : ''}
           </h2>
         </div>
       </div>
@@ -40,7 +40,7 @@ const Header: React.FC<HeaderProps> = ({ onMenuToggle }) => {
             <User className="w-4 h-4 text-white" />
           </div>
           <div className="hidden md:block">
-            <p className="text-sm font-medium text-gray-800">{user?.name}</p>
+            <p className="text-sm font-medium text-gray-800">{user ? `${user.prenom} ${user.nom}` : ''}</p>
             <p className="text-xs text-gray-600 capitalize">{user?.role}</p>
           </div>
         </div>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import LoadingSpinner from '../components/ui/LoadingSpinner';
+import { useAuth } from '../contexts/AuthContext';
+import api from '../lib/api';
+import { User } from '../types';
+
+const ProfilePage: React.FC = () => {
+  const { user } = useAuth();
+  const [profile, setProfile] = useState<User | null>(user);
+  const [loading, setLoading] = useState(!user);
+
+  useEffect(() => {
+    api.get('/me')
+      .then(res => setProfile(res.data))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Mon Profil</h1>
+        <p className="text-gray-600 mt-1">Informations personnelles de votre compte</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Informations personnelles</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <p><span className="font-medium">Prénom:</span> {profile.prenom}</p>
+          <p><span className="font-medium">Nom:</span> {profile.nom}</p>
+          <p><span className="font-medium">Email:</span> {profile.email}</p>
+          <p><span className="font-medium">Rôle:</span> {profile.role}</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ProfilePage;

--- a/frontend/src/pages/prestataire/PrestataireDashboard.tsx
+++ b/frontend/src/pages/prestataire/PrestataireDashboard.tsx
@@ -67,7 +67,7 @@ const PrestataireDashboard: React.FC = () => {
       <div className="relative bg-gradient-to-r from-blue-600 to-cyan-600 rounded-lg p-8 text-white overflow-hidden">
         <div className="absolute inset-0 bg-[url('https://images.unsplash.com/photo-1581091226825-a6a2a5aee158')] bg-cover bg-center opacity-10"></div>
         <div className="relative z-10">
-          <h1 className="text-3xl font-bold mb-2">Bienvenue, {user?.name}</h1>
+          <h1 className="text-3xl font-bold mb-2">Bienvenue, {user ? `${user.prenom} ${user.nom}` : ''}</h1>
           <p className="text-blue-100 text-lg">Gérez vos projets hydrauliques et contribuez à l'accès à l'eau potable</p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a `ProfilePage` that fetches the logged in user via `/api/me`
- update header and prestataire dashboard to show `prenom` and `nom`
- register the new profile route

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687cf02099748320b878720b95b7723a